### PR TITLE
bug修复

### DIFF
--- a/src/OSharp.EntityFrameworkCore/EntityManager.cs
+++ b/src/OSharp.EntityFrameworkCore/EntityManager.cs
@@ -1,10 +1,10 @@
-﻿// -----------------------------------------------------------------------
-//  <copyright file="EntityRegisterManager.cs" company="OSharp开源团队">
+// -----------------------------------------------------------------------
+//  <copyright file="EntityManager.cs" company="OSharp开源团队">
 //      Copyright (c) 2014-2019 OSharp. All rights reserved.
 //  </copyright>
 //  <site>http://www.osharp.org</site>
-//  <last-editor>郭明锋</last-editor>
-//  <last-date>2019-03-08 3:07</last-date>
+//  <last-editor></last-editor>
+//  <last-date>2019-06-27 9:04</last-date>
 // -----------------------------------------------------------------------
 
 using System;
@@ -64,20 +64,9 @@ namespace OSharp.Entity
             foreach (IGrouping<Type, IEntityRegister> group in groups)
             {
                 key = group.Key ?? typeof(DefaultDbContext);
-                List<IEntityRegister> list = new List<IEntityRegister>();
-                if (group.Key == null || group.Key == typeof(DefaultDbContext))
-                {
-                    list.AddRange(group);
-                }
-                else
-                {
-                    list = group.ToList();
-                }
-
-                if (list.Count > 0)
-                {
-                    dict[key] = list.ToArray();
-                }
+                List<IEntityRegister> list = dict.ContainsKey(key) ? dict[key].ToList() : new List<IEntityRegister>();
+                list.AddRange(group);
+                dict[key] = list.ToArray();
             }
 
             //添加框架的一些默认实体的实体映射信息（如果不存在）

--- a/src/OSharp/Reflection/TypeExtensions.cs
+++ b/src/OSharp/Reflection/TypeExtensions.cs
@@ -1,4 +1,4 @@
-﻿// -----------------------------------------------------------------------
+// -----------------------------------------------------------------------
 //  <copyright file="TypeExtensions.cs" company="OSharp开源团队">
 //      Copyright (c) 2014-2015 OSharp. All rights reserved.
 //  </copyright>
@@ -46,7 +46,7 @@ namespace OSharp.Reflection
             Check.NotNull(type, nameof(type));
             Check.NotNull(baseType, nameof(baseType));
 
-            return type.IsClass && !canAbstract && !type.IsAbstract && type.IsBaseOn(baseType);
+            return type.IsClass && (canAbstract || !type.IsAbstract) && type.IsBaseOn(baseType);
         }
 
         /// <summary>


### PR DESCRIPTION
两个bug修复：
TypeExtensions.cs里的IsDeriveClassFrom方法canAbstract逻辑错误，
EntityManager实体管理初始化错误，如果IEntityRegister.DbContextType如果既有Null又有DefaultDbContext，dict[typeof(DefaultDbContext)]会被覆盖掉