### PR TITLE
修改过滤规则组件

### DIFF
--- a/samples/web/ui/ng-alain8/src/app/shared/components/filter-group/filter-rule.component.html
+++ b/samples/web/ui/ng-alain8/src/app/shared/components/filter-group/filter-rule.component.html
@@ -27,7 +27,7 @@
           <ng-template #NotEnum>
             <!--用户类型-->
             <ng-container *ngIf="property.IsUserFlag&&rule.Operate==3; else NotUser">
-              <nz-select [(ngModel)]="rule.Value" nzMode="tags" nzMaxMultipleCount="1" (ngModelChange)="onTagsChangeEvent($event)" nzSize="small">
+              <nz-select [(ngModel)]="rule.Value" nzSize="small">
                 <nz-option nzValue="@CurrentUserId" nzLabel="@当前用户"></nz-option>
               </nz-select>
             </ng-container>


### PR DESCRIPTION
当是用户类型(IsUserFlag)时，只有一个选项，nzMode属性不需要指定为"tags"。nzMode属性指定为'tags'后，有可能会出错。