### PR TITLE
将JS时间格式的数值转换为时间 判断逻辑错误BUG修复

### DIFF
--- a/src/OSharp/Timing/DateTimeExtensions.cs
+++ b/src/OSharp/Timing/DateTimeExtensions.cs
@@ -87,7 +87,7 @@ namespace OSharp.Timing
         public static DateTime FromJsGetTime(this long jsTime)
         {
             int length = jsTime.ToString().Length;
-            Check.Required<ArgumentException>(length != 10 || length != 13, "JS时间数值的长度不正确，必须为10位或13位");
+            Check.Required<ArgumentException>(length == 10 || length == 13, "JS时间数值的长度不正确，必须为10位或13位");
             DateTime start = new DateTime(1970, 1, 1);
             DateTime result = length == 10 ? start.AddSeconds(jsTime) : start.AddMilliseconds(jsTime);
             return result.FromUtcTime();


### PR DESCRIPTION
将JS时间格式的数值转换为时间 判断逻辑错误BUG修复