### PR TITLE
增加泛型AjaxResult<T>

### DIFF
--- a/samples/web/Liuliu.Demo.WebApi/Liuliu.Demo.WebApi.csproj
+++ b/samples/web/Liuliu.Demo.WebApi/Liuliu.Demo.WebApi.csproj
@@ -42,6 +42,8 @@
 
   <ItemGroup>
     <ProjectReference Include="..\..\..\src\OSharp.AutoMapper\OSharp.AutoMapper.csproj" />
+    <ProjectReference Include="..\..\..\src\OSharp.EntityFrameworkCore.MySql\OSharp.EntityFrameworkCore.MySql.csproj" />
+    <ProjectReference Include="..\..\..\src\OSharp.EntityFrameworkCore.Oracle\OSharp.EntityFrameworkCore.Oracle.csproj" />
     <ProjectReference Include="..\..\..\src\OSharp.EntityFrameworkCore.PostgreSql\OSharp.EntityFrameworkCore.PostgreSql.csproj" />
     <ProjectReference Include="..\..\..\src\OSharp.EntityFrameworkCore.Sqlite\OSharp.EntityFrameworkCore.Sqlite.csproj" />
     <ProjectReference Include="..\..\..\src\OSharp.EntityFrameworkCore.SqlServer\OSharp.EntityFrameworkCore.SqlServer.csproj" />

--- a/src/OSharp.AspNetCore/Mvc/Filters/UnitOfWorkImpl.cs
+++ b/src/OSharp.AspNetCore/Mvc/Filters/UnitOfWorkImpl.cs
@@ -7,6 +7,8 @@
 //  <last-date>2019-05-14 17:37</last-date>
 // -----------------------------------------------------------------------
 
+using Newtonsoft.Json;
+
 namespace OSharp.AspNetCore.Mvc.Filters;
 
 /// <summary>
@@ -55,6 +57,7 @@ internal class UnitOfWorkImpl : IActionFilter
                 context.ExceptionHandled = true;
             }
         }
+        var x = context.Result;
         if (context.Result is JsonResult result1)
         {
             if (result1.Value is AjaxResult ajax)
@@ -80,7 +83,20 @@ internal class UnitOfWorkImpl : IActionFilter
             }
             else
             {
-                _unitOfWork?.Commit();
+                try
+                {
+                    var ajax2 = JsonConvert.DeserializeObject<AjaxResult>(result2.Value.ToJsonString());
+                    type = ajax2.Type;
+                    message = ajax2.Content;
+                    if (ajax2.Succeeded())
+                    {
+                        _unitOfWork?.Commit();
+                    }
+                }
+                catch
+                {
+                    _unitOfWork?.Commit();
+                }
             }
         }
         //普通请求

--- a/src/OSharp.AspNetCore/UI/AjaxResult.cs
+++ b/src/OSharp.AspNetCore/UI/AjaxResult.cs
@@ -46,6 +46,36 @@ public class AjaxResult
     { }
 
     /// <summary>
+    /// 初始化一个<see cref="AjaxResult"/>类型的新实例
+    /// </summary>
+    public AjaxResult(AjaxResultType type, string content, object data)
+    {
+        Type = type;
+        Content = content;
+        Data = data;
+    }
+
+    /// <summary>
+    /// 初始化一个<see cref="AjaxResult"/>类型的新实例
+    /// </summary>
+    public AjaxResult(AjaxResultType type, string content)
+    {
+        Type = type;
+        Content = content;
+        Data = null;
+    }
+
+    /// <summary>
+    /// 初始化一个<see cref="AjaxResult"/>类型的新实例
+    /// </summary>
+    public AjaxResult(string content)
+    {
+        Type = AjaxResultType.Success;
+        Content = content;
+        Data = null;
+    }
+
+    /// <summary>
     /// 获取或设置 Ajax操作结果类型
     /// </summary>
     public AjaxResultType Type { get; set; }
@@ -80,6 +110,109 @@ public class AjaxResult
     /// 成功的AjaxResult
     /// </summary>
     public static AjaxResult Success(object data = null)
+    {
+        return new AjaxResult("操作执行成功", AjaxResultType.Success, data);
+    }
+}
+
+public class AjaxResult<T> where T : class
+{
+    /// <summary>
+    /// 初始化一个<see cref="AjaxResult"/>类型的新实例
+    /// </summary>
+    public AjaxResult()
+        : this(null)
+    { }
+
+    /// <summary>
+    /// 初始化一个<see cref="AjaxResult"/>类型的新实例
+    /// </summary>
+    public AjaxResult(string content, AjaxResultType type = AjaxResultType.Success, T data = null)
+        : this(content, data, type)
+    { }
+
+    /// <summary>
+    /// 初始化一个<see cref="AjaxResult"/>类型的新实例
+    /// </summary>
+    public AjaxResult(string content, T data, AjaxResultType type = AjaxResultType.Success)
+    {
+        Type = type;
+        Content = content;
+        Data = data;
+    }
+
+    /// <summary>
+    /// 初始化一个<see cref="AjaxResult"/>类型的新实例
+    /// </summary>
+    public AjaxResult(T data, AjaxResultType type = AjaxResultType.Success, string content = null)
+        : this(content ?? type.ToDescription(), data, type)
+    { }
+
+    /// <summary>
+    /// 初始化一个<see cref="AjaxResult"/>类型的新实例
+    /// </summary>
+    public AjaxResult(AjaxResultType type, string content, T data)
+    {
+        Type = type;
+        Content = content;
+        Data = data;
+    }
+
+    /// <summary>
+    /// 初始化一个<see cref="AjaxResult"/>类型的新实例
+    /// </summary>
+    public AjaxResult(AjaxResultType type, string content)
+    {
+        Type = type;
+        Content = content;
+        Data = null;
+    }
+
+    /// <summary>
+    /// 初始化一个<see cref="AjaxResult"/>类型的新实例
+    /// </summary>
+    public AjaxResult(string content)
+    {
+        Type = AjaxResultType.Success;
+        Content = content;
+        Data = null;
+    }
+
+    /// <summary>
+    /// 获取或设置 Ajax操作结果类型
+    /// </summary>
+    public AjaxResultType Type { get; set; }
+
+    /// <summary>
+    /// 获取或设置 消息内容
+    /// </summary>
+    public string Content { get; set; }
+
+    /// <summary>
+    /// 获取或设置 返回数据
+    /// </summary>
+    public T Data { get; set; }
+
+    /// <summary>
+    /// 是否成功
+    /// </summary>
+    public bool Succeeded()
+    {
+        return Type == AjaxResultType.Success;
+    }
+
+    /// <summary>
+    /// 是否错误
+    /// </summary>
+    public bool Error()
+    {
+        return Type == AjaxResultType.Error;
+    }
+
+    /// <summary>
+    /// 成功的AjaxResult
+    /// </summary>
+    public static AjaxResult Success(T data = null)
     {
         return new AjaxResult("操作执行成功", AjaxResultType.Success, data);
     }

--- a/src/OSharp.AspNetCore/UI/AjaxResultExtensions.cs
+++ b/src/OSharp.AspNetCore/UI/AjaxResultExtensions.cs
@@ -57,6 +57,35 @@ public static class AjaxResultExtensions
     }
 
     /// <summary>
+    /// 将业务操作结果转ajax操作结果，并处理强类型的 OperationResult.Data
+    /// </summary>
+    public static AjaxResult<T> ToAjaxResultEx<T>(this OperationResult<T> result, Func<T, T> dataFunc = null) where T : class
+    {
+        string content = result.Message ?? result.ResultType.ToDescription();
+        AjaxResultType type = result.ResultType.ToAjaxResultType();
+        T data = dataFunc == null ? result.Data : dataFunc(result.Data);
+        return new AjaxResult<T>(content, type, data);
+    }
+
+    /// <summary>
+    /// 将业务操作结果转ajax操作结果，会将 object 类型的 OperationResult.Data 转换为强类型 T，再通过 dataFunc 进行进一步处理
+    /// </summary>
+    public static AjaxResult<T> ToAjaxResultEx<T>(this OperationResult result, Func<T, T> dataFunc) where T : class
+    {
+        string content = result.Message ?? result.ResultType.ToDescription();
+        AjaxResultType type = result.ResultType.ToAjaxResultType();
+        T data = null;
+        if (result.Data != null)
+        {
+            if (dataFunc != null && result.Data is T resultData)
+            {
+                data = dataFunc(resultData);
+            }
+        }
+        return new AjaxResult<T>(content, type, data);
+    }
+
+    /// <summary>
     /// 把业务结果类型<see cref="OperationResultType"/>转换为Ajax结果类型<see cref="AjaxResultType"/>
     /// </summary>
     public static AjaxResultType ToAjaxResultType(this OperationResultType resultType)

--- a/src/OSharp.EntityFrameworkCore/OSharp.EntityFrameworkCore.csproj
+++ b/src/OSharp.EntityFrameworkCore/OSharp.EntityFrameworkCore.csproj
@@ -13,6 +13,7 @@
 
   <ItemGroup>
     <PackageReference Include="Dapper" Version="2.0.123" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="7.0.0" />
   </ItemGroup>
   <ItemGroup Condition="'$(TargetFramework)'=='net6.0'">
     <PackageReference Include="Microsoft.EntityFrameworkCore.Proxies" Version="[6.0.11, 7.0.0)" />

--- a/src/OSharp.EntityFrameworkCore/ServiceExtensions.cs
+++ b/src/OSharp.EntityFrameworkCore/ServiceExtensions.cs
@@ -8,6 +8,8 @@
 // -----------------------------------------------------------------------
 
 
+using Microsoft.EntityFrameworkCore.Diagnostics;
+
 namespace OSharp.Entity;
 
 /// <summary>
@@ -48,6 +50,15 @@ public static class ServiceExtensions
         {
             throw new OsharpException($"无法找到数据上下文 {dbContextType.DisplayName()} 的配置信息");
         }
+
+        builder.ConfigureWarnings(warnings => warnings.Ignore(CoreEventId.DetachedLazyLoadingWarning)); ////忽略AsNoTracking 报错
+
+#if DEBUG
+        builder.UseLoggerFactory((LoggerFactory.Create(options =>
+        {
+            options.AddConsole();//开启ef打印sql语句
+        })));
+#endif
 
         ILogger logger = provider.GetLogger(typeof(ServiceExtensions));
         //启用延迟加载


### PR DESCRIPTION
增加泛型AjaxResult<T>，这样在swagger中可以显示具体的数据类型，因为系统默认的AjaxResult在swagger中无法显示具体的数据类型