### PR TITLE
GetDbContextInternal获取dbcontext时，未必是配置文件中配置的连接字符串，特别是多租户场景下，所以采用dbContext.Database.GetDbConnection().ConnectionString获取连接字符串更合理

### DIFF
--- a/src/OSharp.EntityFrameworkCore/UnitOfWork.cs
+++ b/src/OSharp.EntityFrameworkCore/UnitOfWork.cs
@@ -122,11 +122,14 @@ public class UnitOfWork : Disposable, IUnitOfWork
             throw new OsharpException($"数据上下文 {dbContext.GetType().FullName} 的数据库不存在，请通过 Migration 功能进行数据迁移创建数据库。");
         }
 
+        string connectionString = dbContext.Database.GetDbConnection().ConnectionString;
+        
         //将连接对象DbConnection缓存到ScopedDictionary，在再次构建DbContextOptionsBuilder的时候可以直接使用
-        OsharpDbContextOptions dbContextOptions = _provider.GetOSharpOptions().GetDbContextOptions(dbContextType);
+        //OsharpDbContextOptions dbContextOptions = _provider.GetOSharpOptions().GetDbContextOptions(dbContextType);
         ScopedDictionary scopedDictionary = _provider.GetRequiredService<ScopedDictionary>();
         DbConnection connection = dbContext.Database.GetDbConnection();
-        scopedDictionary.TryAdd($"DbConnection_{dbContextOptions.ConnectionString}", connection);
+        //scopedDictionary.TryAdd($"DbConnection_{dbContextOptions.ConnectionString}", connection);
+        scopedDictionary.TryAdd($"DbConnection_{connectionString}", connection);
 
         //缓存DbContext
         if (_contextDict.TryGetValue(connection, out List<DbContextBase> value))

--- a/src/OSharp.Utils/OSharp.Utils.csproj
+++ b/src/OSharp.Utils/OSharp.Utils.csproj
@@ -27,15 +27,15 @@
     <PackageReference Include="System.Reflection.Emit.Lightweight" Version="4.*" />
     <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.*" />
     <PackageReference Include="System.Text.Encoding.CodePages" Version="9.*" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="9.*" />
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="9.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="9.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="9.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="9.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="9.*" />
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.*" />
-    <PackageReference Include="Microsoft.Extensions.Http" Version="9.*" />
-    <PackageReference Include="Microsoft.Extensions.Logging" Version="9.*" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Abstractions" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Abstractions" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Binder" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.FileExtensions" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.Json" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Http" Version="8.*" />
+    <PackageReference Include="Microsoft.Extensions.Logging" Version="8.*" />
   </ItemGroup>
 
 


### PR DESCRIPTION
GetDbContextInternal获取dbcontext时，未必是配置文件中配置的连接字符串，特别是多租户场景下，所以采用dbContext.Database.GetDbConnection().ConnectionString获取连接字符串更合理